### PR TITLE
3 clock Load - Separated edges

### DIFF
--- a/test/pVIPRAM_inputBuilderClass.py
+++ b/test/pVIPRAM_inputBuilderClass.py
@@ -190,6 +190,9 @@ class inputBuilder:
             self.cycleCtr += 1;
             self.tree.Fill();
             ctrMF += 1; 
+        if ctrMF == 0:
+            self.cycleCtr += 1;
+            self.tree.Fill();
 
         # secondary
         # set ternary bits
@@ -242,7 +245,10 @@ class inputBuilder:
         while ctrMF < multiplicativeFactor:
             self.cycleCtr += 1;
             self.tree.Fill();
-            ctrMF += 1; 
+            ctrMF += 1;
+        if ctrMF == 0:
+            self.cycleCtr += 1;
+            self.tree.Fill();
 
         #print self.DataOut
 


### PR DESCRIPTION
When using the argument 0, the negedge of latch overlaps with negedge of data. This showed to produce unwanted spikes in simulations. Just separating them. 
